### PR TITLE
default to edgebreaker encoding

### DIFF
--- a/src/draco/unity/draco_unity_enc_plugin.cc
+++ b/src/draco/unity/draco_unity_enc_plugin.cc
@@ -60,6 +60,8 @@ namespace draco {
       
       if (preserveTriangleOrder) {
           dracoEncoder.SetEncodingMethod(draco::MESH_SEQUENTIAL_ENCODING);
+      } else {
+          dracoEncoder.SetEncodingMethod(draco::MESH_EDGEBREAKER_ENCODING);
       }
       
       auto encoderStatus = dracoEncoder.EncodeMeshToBuffer(encoder->mesh, &encoder->encoderBuffer);


### PR DESCRIPTION
Minor fix - `MESH_SEQUENTIAL_ENCODING` seems to be the default (I get no size difference when turning on or off `preserveTriangleOrder`).  This simply sets `MESH_EDGEBREAKER_ENCODING` as the alternative when `preserveTriangleOrder == false`.