### PR TITLE
Include  x86_64 plugin in build workflow

### DIFF
--- a/.github/workflows/unity.yml
+++ b/.github/workflows/unity.yml
@@ -300,6 +300,21 @@ jobs:
     - name: build_android_x86_dracoenc_unity
       run: cmake --build build_android_x86 --target dracoenc_unity -j
 
+    - name: configure_android_x86_64
+      run: >
+        cmake -B build_android_x86_64 -DANDROID_ABI=x86_64
+        -DCMAKE_BUILD_TYPE=MinSizeRel
+        -DANDROID_NDK=${{ steps.setup-ndk.outputs.ndk-path }}
+        -DCMAKE_TOOLCHAIN_FILE="${{ steps.setup-ndk.outputs.ndk-path }}/build/cmake/android.toolchain.cmake"
+        -DDRACO_UNITY_PLUGIN=ON
+        -DDRACO_GLTF_BITSTREAM=ON
+        -DDRACO_BACKWARDS_COMPATIBILITY=OFF
+    - name: build_android_x86_64_dracodec_unity
+      run: cmake --build build_android_x86_64 --target dracodec_unity -j
+    - name: build_android_x86_64_dracoenc_unity
+      run: cmake --build build_android_x86_64 --target dracoenc_unity -j
+
+
     # Emscripten
     - name: setup Emscripten
       uses: mymindstorm/setup-emsdk@v12
@@ -328,6 +343,7 @@ jobs:
         mkdir -p draco_linux/Android/libs/arm64-v8a
         mkdir -p draco_linux/Android/libs/armeabi-v7a
         mkdir -p draco_linux/Android/libs/x86
+        mkdir -p draco_linux/Android/libs/x86_64
         mv build_android_arm64-v8a/libdracodec_unity.so \
           draco_linux/Android/libs/arm64-v8a
         mv build_android_arm64-v8a/libdracoenc_unity.so \
@@ -340,6 +356,10 @@ jobs:
           draco_linux/Android/libs/x86
         mv build_android_x86/libdracoenc_unity.so \
           draco_linux/Android/libs/x86
+        mv build_android_x86_64/libdracodec_unity.so \
+          draco_linux/Android/libs/x86_64
+        mv build_android_x86_64/libdracoenc_unity.so \
+          draco_linux/Android/libs/x86_64
     - name: upload artifact
       uses: actions/upload-artifact@v3
       with:


### PR DESCRIPTION
Updated the unity.yml file to include the x86_64 version of the draco plugin